### PR TITLE
Await SharedPreferences writes

### DIFF
--- a/lib/shared_preferences_typed.dart
+++ b/lib/shared_preferences_typed.dart
@@ -45,6 +45,10 @@ class PrefKeyNullable<T> {
   /// Use `.read()` if you don't have an existing [SharedPreferences] instance.
   /// Returns [defaultValue] during test mode.
   Future<T?> readSync(SharedPreferences prefs) async {
+    // Dart 2 can't parse Dart 3's `case const (List<String>)` constant pattern,
+    // while bare `case List<String>` is invalid in Dart 3. Replace this alias with
+    // `case const (List<String>)` once Dart versions below 3 are no longer supported.
+    const Type stringListType = List<String>;
     switch (T) {
       case bool:
         return prefs.getBool(key) as T?;
@@ -54,7 +58,7 @@ class PrefKeyNullable<T> {
         return prefs.getInt(key) as T?;
       case String:
         return prefs.getString(key) as T?;
-      case List<String>:
+      case stringListType:
         return prefs.getStringList(key) as T?;
       default:
         return prefs.get(key) as T?;
@@ -65,7 +69,7 @@ class PrefKeyNullable<T> {
   /// Does nothing during test mode.
   Future<void> write(T value, [SharedPreferences? prefs]) async {
     final p = prefs ?? await SharedPreferences.getInstance();
-    writeSync(value, p);
+    await writeSync(value, p);
   }
 
   /// Write a value to [SharedPreferences].
@@ -76,24 +80,32 @@ class PrefKeyNullable<T> {
       value != null,
       "You can't write null to SharedPreferences. Use key.remove() instead.",
     );
+    const Type stringListType = List<String>;
+    late final Future<bool> writeResult;
     switch (T) {
       case bool:
-        prefs.setBool(key, value as bool);
+        writeResult = prefs.setBool(key, value as bool);
         break;
       case double:
-        prefs.setDouble(key, value as double);
+        writeResult = prefs.setDouble(key, value as double);
         break;
       case int:
-        prefs.setInt(key, value as int);
+        writeResult = prefs.setInt(key, value as int);
         break;
       case String:
-        prefs.setString(key, value as String);
+        writeResult = prefs.setString(key, value as String);
         break;
-      case List<String>:
-        prefs.setStringList(key, value as List<String>);
+      case stringListType:
+        writeResult = prefs.setStringList(key, value as List<String>);
         break;
       default:
-        assert(false, "write was called with an unsupported type: $T");
+        throw UnsupportedError(
+          "write was called with an unsupported type: $T",
+        );
+    }
+
+    if (!await writeResult) {
+      throw StateError("Could not persist SharedPreferences key '$key'.");
     }
   }
 

--- a/test/shared_preferences_typed_test.dart
+++ b/test/shared_preferences_typed_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -39,36 +41,69 @@ void main() {
   });
 
   test('Async, nullable', () async {
-    _testKeyAsyncNullable(_kBoolNullable, _demoBool);
-    _testKeyAsyncNullable(_kDoubleNullable, _demoDouble);
-    _testKeyAsyncNullable(_kIntNullable, _demoInt);
-    _testKeyAsyncNullable(_kStringNullable, _demoString);
-    _testKeyAsyncNullable(_kListNullable, _demoList);
+    await _testKeyAsyncNullable(_kBoolNullable, _demoBool);
+    await _testKeyAsyncNullable(_kDoubleNullable, _demoDouble);
+    await _testKeyAsyncNullable(_kIntNullable, _demoInt);
+    await _testKeyAsyncNullable(_kStringNullable, _demoString);
+    await _testKeyAsyncNullable(_kListNullable, _demoList);
   });
 
   test('Async, non-nullable', () async {
-    _testKeyAsyncNonNullable(_kBool, _demoBool, _defaultBool);
-    _testKeyAsyncNonNullable(_kDouble, _demoDouble, _defaultDouble);
-    _testKeyAsyncNonNullable(_kInt, _demoInt, _defaultInt);
-    _testKeyAsyncNonNullable(_kString, _demoString, _defaultString);
-    _testKeyAsyncNonNullable(_kList, _demoList, _defaultList);
+    await _testKeyAsyncNonNullable(_kBool, _demoBool, _defaultBool);
+    await _testKeyAsyncNonNullable(_kDouble, _demoDouble, _defaultDouble);
+    await _testKeyAsyncNonNullable(_kInt, _demoInt, _defaultInt);
+    await _testKeyAsyncNonNullable(_kString, _demoString, _defaultString);
+    await _testKeyAsyncNonNullable(_kList, _demoList, _defaultList);
   });
 
   test('Sync, nullable', () async {
-    _testKeySyncNullable(_kBoolNullable, _demoBool);
-    _testKeySyncNullable(_kDoubleNullable, _demoDouble);
-    _testKeySyncNullable(_kIntNullable, _demoInt);
-    _testKeySyncNullable(_kStringNullable, _demoString);
-    _testKeySyncNullable(_kListNullable, _demoList);
+    await _testKeySyncNullable(_kBoolNullable, _demoBool);
+    await _testKeySyncNullable(_kDoubleNullable, _demoDouble);
+    await _testKeySyncNullable(_kIntNullable, _demoInt);
+    await _testKeySyncNullable(_kStringNullable, _demoString);
+    await _testKeySyncNullable(_kListNullable, _demoList);
   });
 
   test('Sync, non-nullable', () async {
-    _testKeySyncNonNullable(_kBool, _demoBool, _defaultBool);
-    _testKeySyncNonNullable(_kDouble, _demoDouble, _defaultDouble);
-    _testKeySyncNonNullable(_kInt, _demoInt, _defaultInt);
-    _testKeySyncNonNullable(_kString, _demoString, _defaultString);
-    _testKeySyncNonNullable(_kList, _demoList, _defaultList);
+    await _testKeySyncNonNullable(_kBool, _demoBool, _defaultBool);
+    await _testKeySyncNonNullable(_kDouble, _demoDouble, _defaultDouble);
+    await _testKeySyncNonNullable(_kInt, _demoInt, _defaultInt);
+    await _testKeySyncNonNullable(_kString, _demoString, _defaultString);
+    await _testKeySyncNonNullable(_kList, _demoList, _defaultList);
   });
+
+  test('Write waits for the underlying persistence operation', () async {
+    final persistenceResult = Completer<bool>();
+    final prefs = _ControlledSharedPreferences(persistenceResult.future);
+    var completed = false;
+
+    final write =
+        _kString.write(_demoString, prefs).whenComplete(() => completed = true);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(completed, isFalse);
+    persistenceResult.complete(true);
+    await write;
+    expect(completed, isTrue);
+  });
+
+  test('Write reports a failed persistence operation', () async {
+    final prefs = _ControlledSharedPreferences(Future.value(false));
+
+    await expectLater(_kString.write(_demoString, prefs), throwsStateError);
+  });
+}
+
+class _ControlledSharedPreferences implements SharedPreferences {
+  _ControlledSharedPreferences(this._persistenceResult);
+
+  final Future<bool> _persistenceResult;
+
+  @override
+  Future<bool> setString(String key, String value) => _persistenceResult;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 Future<void> _testKeyAsyncNullable<T>(


### PR DESCRIPTION
## Summary

- await the underlying SharedPreferences write before completing
- throw when SharedPreferences reports a failed persistence operation
- keep the `List<String>` type switch compatible with Dart 2 and Dart 3
- await the existing asynchronous test helpers and add write-completion regression coverage

## Testing

- `flutter analyze`
- `flutter test`